### PR TITLE
[Feat]: 이메일인증

### DIFF
--- a/src/main/java/com/example/demo/common/ResultDto.java
+++ b/src/main/java/com/example/demo/common/ResultDto.java
@@ -1,0 +1,14 @@
+package com.example.demo.common;
+
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+public class ResultDto<T> {
+
+    private final String message;
+    private final T data;
+
+}

--- a/src/main/java/com/example/demo/common/dto/CheckDto.java
+++ b/src/main/java/com/example/demo/common/dto/CheckDto.java
@@ -1,0 +1,16 @@
+package com.example.demo.common.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+@Setter
+public class CheckDto {
+
+    private Boolean success;
+
+    private String message;
+
+}

--- a/src/main/java/com/example/demo/common/dto/ResultDto.java
+++ b/src/main/java/com/example/demo/common/dto/ResultDto.java
@@ -1,4 +1,4 @@
-package com.example.demo.common;
+package com.example.demo.common.dto;
 
 
 import lombok.Data;

--- a/src/main/java/com/example/demo/common/service/RedisService.java
+++ b/src/main/java/com/example/demo/common/service/RedisService.java
@@ -1,0 +1,55 @@
+package com.example.demo.common.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+
+    public String getData(String key) {
+        ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+        return (String) valueOperations.get(key);
+    }
+
+    public int getIntData(String key) {
+        ValueOperations<String, Object> stringObjectValueOperations = redisTemplate.opsForValue();
+
+        return (Integer) stringObjectValueOperations.get(key);
+    }
+
+    public void setDataExpire(String key, String value, Long expiredTime) {
+        ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(key, value, Duration.ofMillis(expiredTime));
+
+    }
+
+    public void setData(String key, int value) {
+        ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(key, value);
+
+    }
+
+    public void findByLoginId(String id) {
+        redisTemplate.opsForValue().get(id);
+    }
+
+
+
+    public boolean existData(String key) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    public void deleteData(String key) {
+        redisTemplate.delete(key);
+    }
+
+
+}

--- a/src/main/java/com/example/demo/config/RedisConfig.java
+++ b/src/main/java/com/example/demo/config/RedisConfig.java
@@ -1,0 +1,52 @@
+package com.example.demo.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // 일반적인 key:value 시리얼라이저
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        // Hash 사용할 경우 시리얼라이저
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        // 모든 경우
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+
+
+
+
+
+
+
+}

--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -1,0 +1,37 @@
+package com.example.demo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+
+public class SecurityConfig {
+
+    @Bean
+    protected SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http.csrf(CsrfConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers("/api").permitAll()
+                        .anyRequest().permitAll());
+
+
+        return http.build();
+
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/example/demo/config/SwaggerConfig.java
+++ b/src/main/java/com/example/demo/config/SwaggerConfig.java
@@ -1,0 +1,57 @@
+package com.example.demo.config;
+
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+
+@OpenAPIDefinition(
+        info = @Info(
+
+                title = "BASKETBALL API DOCUMENT",
+                description = "API DOCUMENT",
+                version = "v0.1",
+                contact = @Contact(
+                        name = "BASKETBALL",
+                        email = "admin@hoops.com"
+                )
+
+        ),
+        tags = {
+                @Tag(name = "1. USER", description = "회원 기능")
+        }
+
+
+)
+
+@Configuration
+public class SwaggerConfig {
+
+
+    @Bean
+    public OpenAPI openAPI() {
+
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP).scheme("Bearer").bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER).name("Authorization");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("bearerAuth");
+
+        return new OpenAPI()
+                .components(
+                        new Components().addSecuritySchemes("bearerAuth", securityScheme)
+                ).security(Arrays.asList(securityRequirement));
+    }
+
+
+}

--- a/src/main/java/com/example/demo/entity/BaseEntity.java
+++ b/src/main/java/com/example/demo/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass // 상속받는 엔티티에 필드 매핑됨
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/demo/entity/UserEntity.java
+++ b/src/main/java/com/example/demo/entity/UserEntity.java
@@ -1,0 +1,70 @@
+package com.example.demo.entity;
+
+import com.example.demo.users.type.GenderType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "users")
+public class UserEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int userId;
+
+    @Column(nullable = false)
+    private String loginId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private LocalDate birthday;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private GenderType gender;
+
+    @Column(nullable = false)
+    private String nickname;
+
+
+    /**
+     * @ElementCollection -> 값 컬렉션을 테이블로 관리할 때 사용하는 어노테이션
+     * @CollectionTable -> 저장할 테이블을 명시
+     * fetch -> Eager: 엔티티를 조회할때 무조건 같이 조회
+     * fetch -> LAZY: 실제 사용될 때까지는 안불러옴
+     */
+
+
+    @ElementCollection
+    @CollectionTable(
+            name = "user_role", joinColumns = @JoinColumn(name = "user_id")
+    )
+    private List<String> roles;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean emailAuth = false;
+
+
+    public void confirmEmailAuth() {
+        this.emailAuth = true;
+    }
+
+}

--- a/src/main/java/com/example/demo/exception/ErrorCode.java
+++ b/src/main/java/com/example/demo/exception/ErrorCode.java
@@ -15,7 +15,10 @@ public enum ErrorCode {
     NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
     EXIST_EMAIL(HttpStatus.BAD_REQUEST.value(), "이미 사용중인 이메일 입니다."),
     EXIST_LOGIN_ID(HttpStatus.BAD_REQUEST.value(), "이미 사용중인 아이디입니다."),
-    EXIST_NICKNAME(HttpStatus.BAD_REQUEST.value(), "이미 사용중인 닉네임입니다.");
+    EXIST_NICKNAME(HttpStatus.BAD_REQUEST.value(), "이미 사용중인 닉네임입니다."),
+    NOT_EXIST_EMAIL(HttpStatus.BAD_REQUEST.value(), "이메일이 존재하지 않습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "내부 서버 오류입니다."),
+    INVALID_CODE(HttpStatus.BAD_REQUEST.value(), "유효하지않은 인증번호입니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/example/demo/exception/ErrorCode.java
+++ b/src/main/java/com/example/demo/exception/ErrorCode.java
@@ -11,7 +11,11 @@ public enum ErrorCode {
 
     INVALID_INPUT(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 입력 값입니다."),
     INVALID_PATTERN(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 패턴입니다."),
-    PAST_DATE_REQUIRE(HttpStatus.BAD_REQUEST.value(), "과거 날짜를 입력해주세요.");
+    PAST_DATE_REQUIRE(HttpStatus.BAD_REQUEST.value(), "과거 날짜를 입력해주세요."),
+    NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
+    EXIST_EMAIL(HttpStatus.BAD_REQUEST.value(), "이미 사용중인 이메일 입니다."),
+    EXIST_LOGIN_ID(HttpStatus.BAD_REQUEST.value(), "이미 사용중인 아이디입니다."),
+    EXIST_NICKNAME(HttpStatus.BAD_REQUEST.value(), "이미 사용중인 닉네임입니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/example/demo/users/controller/UserController.java
+++ b/src/main/java/com/example/demo/users/controller/UserController.java
@@ -1,0 +1,35 @@
+package com.example.demo.users.controller;
+
+
+import com.example.demo.common.ResultDto;
+import com.example.demo.users.dto.SignUpDto;
+import com.example.demo.users.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+@Tag(name = "1. USER")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    @Operation(summary = "회원 가입")
+    public ResponseEntity<ResultDto<SignUpDto.Response>> signup(@RequestBody @Validated SignUpDto.Request request) {
+
+        ResultDto<SignUpDto.Response> responseResultDto = userService.signUp(request);
+
+        return ResponseEntity.ok(responseResultDto);
+
+    }
+
+}

--- a/src/main/java/com/example/demo/users/controller/UserController.java
+++ b/src/main/java/com/example/demo/users/controller/UserController.java
@@ -1,18 +1,18 @@
 package com.example.demo.users.controller;
 
 
-import com.example.demo.common.ResultDto;
+import com.example.demo.common.dto.CheckDto;
+import com.example.demo.common.dto.ResultDto;
+import com.example.demo.users.dto.SendMailDto;
 import com.example.demo.users.dto.SignUpDto;
+import com.example.demo.users.service.MailService;
 import com.example.demo.users.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +22,8 @@ public class UserController {
 
     private final UserService userService;
 
+    private final MailService mailService;
+
     @PostMapping("/signup")
     @Operation(summary = "회원 가입")
     public ResponseEntity<ResultDto<SignUpDto.Response>> signup(@RequestBody @Validated SignUpDto.Request request) {
@@ -29,6 +31,26 @@ public class UserController {
         ResultDto<SignUpDto.Response> responseResultDto = userService.signUp(request);
 
         return ResponseEntity.ok(responseResultDto);
+
+    }
+
+    @PostMapping("/sendMail")
+    public ResponseEntity<CheckDto> sendMail(@RequestParam @Validated SendMailDto.Request request) {
+
+        CheckDto checkDto = mailService.sendEmail(request);
+
+        return ResponseEntity.ok(checkDto);
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<CheckDto> verifyCode(
+            @RequestParam String email,
+            @RequestParam String code
+    ) {
+
+        CheckDto checkDto = mailService.verifyEmail(email, code);
+
+        return ResponseEntity.ok(checkDto);
 
     }
 

--- a/src/main/java/com/example/demo/users/dto/SendMailDto.java
+++ b/src/main/java/com/example/demo/users/dto/SendMailDto.java
@@ -1,0 +1,21 @@
+package com.example.demo.users.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class SendMailDto {
+
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Request {
+
+        private String email;
+
+
+    }
+
+
+}

--- a/src/main/java/com/example/demo/users/dto/SignUpDto.java
+++ b/src/main/java/com/example/demo/users/dto/SignUpDto.java
@@ -1,0 +1,118 @@
+package com.example.demo.users.dto;
+
+import com.example.demo.entity.UserEntity;
+import com.example.demo.users.type.GenderType;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class SignUpDto {
+
+
+    // 회원가입을 위한 Request
+    // Validation활용 유효성 검사
+    // 클라이언트로부터 Request값을 받는 내부 클래스
+    // Request값으로받은 데이터 UserEntity로 전달 및 DB저장 용도
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Setter
+    public static class Request {
+
+        @NotBlank(message = "아이디를 입력해주세요.")
+        private String loginId;
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,13}$")
+        private String password;
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()])[a-zA-Z\\d~!@#$%^&*()]{8,13}$")
+        private String checkPassword;
+
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "이메일 형식에 맞게 입력해주세요.")
+        private String email;
+
+        @NotBlank(message = "이름을 입력해주세요.")
+        private String name;
+
+        @NotBlank(message = "별명을 입력해주세요.")
+        private String nickname;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING
+        , pattern = "yyyyMMdd"
+        , timezone = "Asia/Seoul")
+        private LocalDate birthday;
+
+        @NotBlank(message = "성별을 입력해주세요.")
+        private String genderType;
+
+        private List<String> roles;
+
+        public static UserEntity toEntity(Request request) {
+
+            return UserEntity.builder()
+                    .loginId(request.getLoginId())
+                    .password(request.getPassword())
+                    .email(request.getEmail())
+                    .name(request.getName())
+                    .nickname(request.getNickname())
+                    .birthday(request.getBirthday())
+                    .gender(GenderType.valueOf(request.getGenderType()))
+                    .roles(List.of("ROLE_USER"))
+                    .build();
+
+        }
+
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Response {
+
+        // UserDto를 사용하여 클라이언트에게 응답값제공
+
+        private int userId;
+
+        private String loginId;
+
+        private String email;
+
+        private String name;
+
+        private String nickname;
+
+        private LocalDate birthday;
+
+        private String genderType;
+
+        private List<String> roles;
+
+        public static Response fromDto(UserDto userDto) {
+
+            return Response.builder()
+                    .userId(userDto.getUserId())
+                    .loginId(userDto.getLoginId())
+                    .email(userDto.getEmail())
+                    .name(userDto.getName())
+                    .nickname(userDto.getNickname())
+                    .birthday(userDto.getBirthday())
+                    .genderType(userDto.getGenderType())
+                    .roles(userDto.getRoles())
+                    .build();
+
+
+        }
+
+    }
+
+}

--- a/src/main/java/com/example/demo/users/dto/SignUpDto.java
+++ b/src/main/java/com/example/demo/users/dto/SignUpDto.java
@@ -68,7 +68,6 @@ public class SignUpDto {
                     .gender(GenderType.valueOf(request.getGenderType()))
                     .roles(List.of("ROLE_USER"))
                     .build();
-
         }
 
     }

--- a/src/main/java/com/example/demo/users/dto/UserDto.java
+++ b/src/main/java/com/example/demo/users/dto/UserDto.java
@@ -1,0 +1,60 @@
+package com.example.demo.users.dto;
+
+import com.example.demo.entity.UserEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor
+public class UserDto {
+
+    // Entity로부터 DB에 저장된 데이터를 응답하는 Dto
+    private int userId;
+
+    private String loginId;
+
+    private String password;
+
+    private String email;
+
+    private String name;
+
+    private String nickname;
+
+    private LocalDate birthday;
+
+    private String genderType;
+
+    private List<String> roles;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    public static UserDto fromEntity(UserEntity userEntity) {
+
+        return UserDto.builder()
+                .userId(userEntity.getUserId())
+                .loginId(userEntity.getLoginId())
+                .password(userEntity.getPassword())
+                .email(userEntity.getEmail())
+                .name(userEntity.getName())
+                .nickname(userEntity.getNickname())
+                .birthday(userEntity.getBirthday())
+                .genderType(String.valueOf(userEntity.getGender()))
+                .roles(userEntity.getRoles())
+                .createdAt(userEntity.getCreatedAt())
+                .updatedAt(userEntity.getUpdatedAt())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/example/demo/users/repository/UserRepository.java
+++ b/src/main/java/com/example/demo/users/repository/UserRepository.java
@@ -3,6 +3,8 @@ package com.example.demo.users.repository;
 import com.example.demo.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<UserEntity, Integer> {
 
     boolean existsByEmail(String email);
@@ -11,4 +13,5 @@ public interface UserRepository extends JpaRepository<UserEntity, Integer> {
 
     boolean existsByLoginId(String loginId);
 
+    Optional<UserEntity> findByEmail(String email);
 }

--- a/src/main/java/com/example/demo/users/repository/UserRepository.java
+++ b/src/main/java/com/example/demo/users/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.example.demo.users.repository;
+
+import com.example.demo.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<UserEntity, Integer> {
+
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
+
+    boolean existsByLoginId(String loginId);
+
+}

--- a/src/main/java/com/example/demo/users/service/MailService.java
+++ b/src/main/java/com/example/demo/users/service/MailService.java
@@ -1,0 +1,130 @@
+package com.example.demo.users.service;
+
+
+import com.example.demo.common.dto.CheckDto;
+import com.example.demo.common.service.RedisService;
+import com.example.demo.entity.UserEntity;
+import com.example.demo.exception.CustomException;
+import com.example.demo.users.dto.SendMailDto;
+import com.example.demo.users.repository.UserRepository;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.sql.Template;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.util.Random;
+
+import static com.example.demo.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender javaMailSender;
+    private final RedisService redisService;
+    private final UserRepository userRepository;
+    private final TemplateEngine templateEngine;
+
+    private static final int CODE_LENGTH = 6;
+
+    private static final Long EMAIL_TOKEN_EXPIRATION = 600000L;
+
+    private static final String EMAIL_PREFIX = "Email_Auth: ";
+
+    public CheckDto sendEmail(SendMailDto.Request request) {
+
+        String code = createRandomCode();
+
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+
+        MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage);
+
+        // HTML 템플릿에 변수 바인딩
+        Context context = new Context();
+        context.setVariable("code", code);
+
+        String html = templateEngine.process("mail/email-auth", context); // 확장자 생략
+
+        boolean exists = userRepository.existsByEmail(request.getEmail());
+
+        if (!exists) {
+            throw new CustomException(NOT_EXIST_EMAIL);
+        }
+
+        try {
+
+            // 인증번호를 전송할 이메일 세팅
+            mimeMessageHelper.setTo(request.getEmail());
+
+            // 제목
+            mimeMessageHelper.setSubject("회원가입 이메일 인증코드입니다.");
+
+            mimeMessageHelper.setText(html, true);
+
+
+
+            // 이메일 전송
+            javaMailSender.send(mimeMessage);
+
+            // 이메일 전송 후 레디스에 Key, Value, 유효시간 저장
+            redisService.setDataExpire(EMAIL_PREFIX + request.getEmail(), code, EMAIL_TOKEN_EXPIRATION);
+
+        } catch (MessagingException e) {
+            throw new CustomException(INTERNAL_SERVER_ERROR);
+        }
+
+        // CheckDto를 활용
+        return new CheckDto(true, "이메일 인증번호를 발송하였습니다.");
+
+    }
+
+
+    public CheckDto verifyEmail(String email, String code) {
+
+        String data = redisService.getData(EMAIL_PREFIX + email);
+
+        if (data == null) {
+            throw new CustomException(NOT_EXIST_EMAIL);
+        }
+
+        // redis에 저장된 인증번호와 이메일로 전송된 이메일 비교
+        boolean validCode = data.equals(code);
+
+        if (!validCode) {
+            throw new CustomException(INVALID_CODE);
+        }
+
+        UserEntity userEntity = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(NOT_EXIST_EMAIL));
+
+        userEntity.confirmEmailAuth();
+
+        // 인증번호 일치 시 UserEntity emailAuth -> true로 변경 후 저장
+        userRepository.save(userEntity);
+
+
+        // 인증 완료된 인증번호는 redis에서 제거
+        redisService.deleteData(EMAIL_PREFIX + email);
+
+        return new CheckDto(validCode, "이메일 인증을 완료하였습니다.");
+    }
+
+    // 인증번호 생성
+    private String createRandomCode() {
+        Random random = new Random();
+        StringBuilder sb = new StringBuilder();
+
+        while (sb.length() < CODE_LENGTH) {
+            sb.append(random.nextInt(10));
+        }
+
+        return sb.toString();
+    }
+
+
+}

--- a/src/main/java/com/example/demo/users/service/UserService.java
+++ b/src/main/java/com/example/demo/users/service/UserService.java
@@ -1,7 +1,7 @@
 package com.example.demo.users.service;
 
 
-import com.example.demo.common.ResultDto;
+import com.example.demo.common.dto.ResultDto;
 import com.example.demo.entity.UserEntity;
 import com.example.demo.exception.CustomException;
 import com.example.demo.users.dto.SignUpDto;
@@ -10,6 +10,8 @@ import com.example.demo.users.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Random;
 
 import static com.example.demo.exception.ErrorCode.*;
 
@@ -55,6 +57,15 @@ public class UserService {
         UserEntity user = userRepository.save(SignUpDto.Request.toEntity(request));
 
         return ResultDto.of("회원가입에 성공하였습니다.", SignUpDto.Response.fromDto(UserDto.fromEntity(user)));
+
+    }
+
+    private static String createRandomNum() {
+
+        Random random = new Random();
+        int certificationNumber = random.nextInt(9999) + 1;
+
+        return String.valueOf(certificationNumber);
 
     }
 

--- a/src/main/java/com/example/demo/users/service/UserService.java
+++ b/src/main/java/com/example/demo/users/service/UserService.java
@@ -1,0 +1,61 @@
+package com.example.demo.users.service;
+
+
+import com.example.demo.common.ResultDto;
+import com.example.demo.entity.UserEntity;
+import com.example.demo.exception.CustomException;
+import com.example.demo.users.dto.SignUpDto;
+import com.example.demo.users.dto.UserDto;
+import com.example.demo.users.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import static com.example.demo.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+
+    /**
+     * 회원가입 서비스
+     * 1. 비밀번호 일치 확인
+     * 2. 중복 체크: 아이디 / 이메일 / 닉네임
+     * 3. 비밀번호 암호화 후 DB 저장
+     * 4. 저장된 유저 정보를 DTO로 변환하여 응답
+     */
+    public ResultDto<SignUpDto.Response> signUp(SignUpDto.Request request) {
+
+        if (!request.getPassword().equals(request.getCheckPassword())) {
+            throw new CustomException(NOT_MATCH_PASSWORD);
+        }
+
+        request.setPassword(passwordEncoder.encode(request.getPassword()));
+
+        boolean idCheck = userRepository.existsByLoginId(request.getLoginId());
+        boolean nicknameCheck = userRepository.existsByNickname(request.getNickname());
+        boolean loginIdCheck = userRepository.existsByLoginId(request.getLoginId());
+
+        if (idCheck) {
+            throw new CustomException(EXIST_LOGIN_ID);
+        }
+
+        if (nicknameCheck) {
+            throw new CustomException(EXIST_NICKNAME);
+        }
+
+        if (loginIdCheck) {
+            throw new CustomException(EXIST_LOGIN_ID);
+        }
+
+        UserEntity user = userRepository.save(SignUpDto.Request.toEntity(request));
+
+        return ResultDto.of("회원가입에 성공하였습니다.", SignUpDto.Response.fromDto(UserDto.fromEntity(user)));
+
+    }
+
+}

--- a/src/main/java/com/example/demo/users/type/GenderType.java
+++ b/src/main/java/com/example/demo/users/type/GenderType.java
@@ -1,0 +1,6 @@
+package com.example.demo.users.type;
+
+public enum GenderType {
+
+    MALE, FEMALE
+}

--- a/src/main/resources/templates/mail/email-auth.html
+++ b/src/main/resources/templates/mail/email-auth.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>인증코드 메일</title>
+</head>
+<body>
+<h1>안녕하세요!</h1>
+<p>아래 인증 코드를 입력해주세요:</p>
+<div style="font-size: 18px; font-weight: bold; color: blue;">
+    인증코드: <span th:text="${code}"></span>
+</div>
+</body>
+</html>


### PR DESCRIPTION
### 변경사항

TO-BE
- 이메일 인증 기능 구현
  - JavaMailSender 활용하여 이메일 전송 후 redis에 인증번호, 유효시간 저장
  - 이메일 인증 -> 클라이언트가 입력한 인증번호와 redis에 저장된 인증번호 일치 비교
  - 일치 시 UserEntity에 emailAuth true로 변경 후 저장 및 redis 인증번호 제거
  - CheckDto를 이용하여 boolean값, 응답메세지 리턴